### PR TITLE
Remove .bundle folder info from SimpleCov reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-### Please see Github Releases section for current releases.
+## HEAD Unreleased
+### Latest update: 2018-07-09
+
+### Bug
+
+- [PR #3](https://github.com/Coveralls-Community/coveralls-ruby/pull/3) Remove .bundle folder info from SimpleCov reports [@vbrazo](https://github.com/vbrazo)
 
 ## 0.7.0 (September 18, 2013)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,10 +17,10 @@ def setup_formatter
     SimpleCov::Formatter::HTMLFormatter
   end
 
-  # SimpleCov.start 'test_frameworks'
   SimpleCov.start do
     add_filter do |source_file|
-      source_file.filename =~ /spec/ && !(source_file.filename =~ /fixture/)
+      source_file.filename =~ /spec/ && source_file.filename !~ /fixture/
+      source_file.filename =~ /.bundle/
     end
   end
 end


### PR DESCRIPTION
- [x] Remove `.bundle` folder info from SimpleCov reports

**Before**

![screen shot 2018-07-09 at 9 27 24 pm](https://user-images.githubusercontent.com/1292556/42482669-4b6a4cf8-83bf-11e8-9b03-4466c8863614.png)

**After**

![screen shot 2018-07-10 at 1 43 01 am](https://user-images.githubusercontent.com/1292556/42489658-a02ddd22-83e2-11e8-83cf-cf98a45c21b8.png)
