### PR TITLE
Finish fixing rubocop violations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Bundler/DuplicatedGem:
   Enabled: false
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 Lint/UnifiedInteger:
@@ -17,6 +20,8 @@ Metrics/CyclomaticComplexity:
 Metrics/LineLength:
   Enabled: false
 Metrics/MethodLength:
+  Enabled: false
+Metrics/ModuleLength:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,8 @@ Style/Documentation:
   Enabled: false
 Style/For:
   Enabled: false
+Style/FormatStringToken:
+  Enabled: false
 Style/RegexpLiteral:
   Enabled: false
 Style/FrozenStringLiteralComment:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+Bundler/DuplicatedGem:
+  Enabled: false
+
 Lint/AmbiguousBlockAssociation:
   Enabled: false
 Lint/UnifiedInteger:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Chores
 
+- [PR #9](https://github.com/Coveralls-Community/coveralls-ruby/pull/9) Finish fixing rubocop violations [@vbrazo](https://github.com/vbrazo)
 - [PR #8](https://github.com/Coveralls-Community/coveralls-ruby/pull/8) Update .travis.yml [@vbrazo](https://github.com/vbrazo)
 - [PR #7](https://github.com/Coveralls-Community/coveralls-ruby/pull/7) Fix rubocop violations manually [@vbrazo](https://github.com/vbrazo)
 - [PR #1](https://github.com/Coveralls-Community/coveralls-ruby/pull/1) Drop 1.8 support, and move some work over from main coveralls [@Ch4s3](https://github.com/Ch4s3)

--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -54,23 +54,23 @@ module Coveralls
   end
 
   def start!(simplecov_setting = 'test_frameworks', &block)
-    if @@adapter == :simplecov
-      ::SimpleCov.add_filter 'vendor'
+    return unless @@adapter == :simplecov
+    
+    ::SimpleCov.add_filter 'vendor'
 
-      if simplecov_setting
-        Coveralls::Output.puts("[Coveralls] Using SimpleCov's '#{simplecov_setting}' settings.", color: 'green')
-        if block_given?
-          ::SimpleCov.start(simplecov_setting) { instance_eval(&block) }
-        else
-          ::SimpleCov.start(simplecov_setting)
-        end
-      elsif block
-        Coveralls::Output.puts('[Coveralls] Using SimpleCov settings defined in block.', color: 'green')
-        ::SimpleCov.start { instance_eval(&block) }
+    if simplecov_setting
+      Coveralls::Output.puts("[Coveralls] Using SimpleCov's '#{simplecov_setting}' settings.", color: 'green')
+      if block_given?
+        ::SimpleCov.start(simplecov_setting) { instance_eval(&block) }
       else
-        Coveralls::Output.puts("[Coveralls] Using SimpleCov's default settings.", color: 'green')
-        ::SimpleCov.start
+        ::SimpleCov.start(simplecov_setting)
       end
+    elsif block
+      Coveralls::Output.puts('[Coveralls] Using SimpleCov settings defined in block.', color: 'green')
+      ::SimpleCov.start { instance_eval(&block) }
+    else
+      Coveralls::Output.puts("[Coveralls] Using SimpleCov's default settings.", color: 'green')
+      ::SimpleCov.start
     end
   end
 

--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -55,7 +55,7 @@ module Coveralls
 
   def start!(simplecov_setting = 'test_frameworks', &block)
     return unless @@adapter == :simplecov
-    
+
     ::SimpleCov.add_filter 'vendor'
 
     if simplecov_setting

--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -40,7 +40,9 @@ module Coveralls
       begin
         require 'simplecov'
         @adapter = :simplecov if defined?(::SimpleCov)
-      rescue StandardError
+      rescue StandardError => error
+        # TODO: Add error action
+        puts error.message
       end
     end
 
@@ -78,6 +80,7 @@ module Coveralls
     # Fail early if we're not on a CI
     unless will_run?
       Coveralls::Output.puts('[Coveralls] Outside the CI environment, not sending data.', color: 'yellow')
+
       return false
     end
 

--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -20,7 +20,7 @@ module Coveralls
 
   def wear_merged!(simplecov_setting = nil, &block)
     require 'simplecov'
-    @@adapter = :simplecov
+    @adapter = :simplecov
     ::SimpleCov.formatter = NilFormatter
     start! simplecov_setting, &block
   end
@@ -33,19 +33,19 @@ module Coveralls
 
   def setup!
     # Try to load up SimpleCov.
-    @@adapter = nil
+    @adapter = nil
     if defined?(::SimpleCov)
-      @@adapter = :simplecov
+      @adapter = :simplecov
     else
       begin
         require 'simplecov'
-        @@adapter = :simplecov if defined?(::SimpleCov)
+        @adapter = :simplecov if defined?(::SimpleCov)
       rescue StandardError
       end
     end
 
     # Load the appropriate adapter.
-    if @@adapter == :simplecov
+    if @adapter == :simplecov
       ::SimpleCov.formatter = Coveralls::SimpleCov::Formatter
       Coveralls::Output.puts('[Coveralls] Set up the SimpleCov formatter.', color: 'green')
     else
@@ -54,7 +54,7 @@ module Coveralls
   end
 
   def start!(simplecov_setting = 'test_frameworks', &block)
-    return unless @@adapter == :simplecov
+    return unless @adapter == :simplecov
 
     ::SimpleCov.add_filter 'vendor'
 

--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -53,7 +53,9 @@ module Coveralls
 
           allow = WebMock::Config.instance.allow || []
           WebMock::Config.instance.allow = [*allow].push API_HOST
-        rescue LoadError
+        rescue StandardError => error
+          # TODO: Add error action
+          puts error.message
         end
 
         begin
@@ -62,7 +64,9 @@ module Coveralls
           VCR.send(VCR.version.major < 2 ? :config : :configure) do |c|
             c.ignore_hosts API_HOST
           end
-        rescue LoadError
+        rescue StandardError
+          # TODO: Add error action
+          puts error.message
         end
       end
 

--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -15,114 +15,118 @@ module Coveralls
 
     API_BASE = "#{API_DOMAIN}/api/v1".freeze
 
-    def self.post_json(endpoint, hash)
-      disable_net_blockers!
+    class << self
+      def post_json(endpoint, hash)
+        disable_net_blockers!
 
-      uri = endpoint_to_uri(endpoint)
+        uri = endpoint_to_uri(endpoint)
 
-      Coveralls::Output.puts(JSON.pretty_generate(hash).to_s, color: 'green') if ENV['COVERALLS_DEBUG']
-      Coveralls::Output.puts("[Coveralls] Submitting to #{API_BASE}", color: 'cyan')
+        Coveralls::Output.puts(JSON.pretty_generate(hash).to_s, color: 'green') if ENV['COVERALLS_DEBUG']
+        Coveralls::Output.puts("[Coveralls] Submitting to #{API_BASE}", color: 'cyan')
 
-      client  = build_client(uri)
-      request = build_request(uri.path, hash)
+        client  = build_client(uri)
+        request = build_request(uri.path, hash)
+        response = client.request(request)
+        response_hash = JSON.parse(response.body.to_str)
 
-      response = client.request(request)
-
-      response_hash = JSON.parse(response.body.to_str)
-
-      if response_hash['message']
-        Coveralls::Output.puts("[Coveralls] #{response_hash['message']}", color: 'cyan')
-      end
-
-      if response_hash['url']
-        Coveralls::Output.puts("[Coveralls] #{Coveralls::Output.format(response_hash['url'], color: 'underline')}", color: 'cyan')
-      end
-
-      case response
-      when Net::HTTPServiceUnavailable
-        Coveralls::Output.puts('[Coveralls] API timeout occured, but data should still be processed', color: 'red')
-      when Net::HTTPInternalServerError
-        Coveralls::Output.puts("[Coveralls] API internal error occured, we're on it!", color: 'red')
-      end
-    end
-
-    private
-
-    def self.disable_net_blockers!
-      begin
-        require 'webmock'
-
-        allow = WebMock::Config.instance.allow || []
-        WebMock::Config.instance.allow = [*allow].push API_HOST
-      rescue LoadError
-      end
-
-      begin
-        require 'vcr'
-
-        VCR.send(VCR.version.major < 2 ? :config : :configure) do |c|
-          c.ignore_hosts API_HOST
+        if response_hash['message']
+          Coveralls::Output.puts("[Coveralls] #{response_hash['message']}", color: 'cyan')
         end
-      rescue LoadError
-      end
-    end
 
-    def self.endpoint_to_uri(endpoint)
-      URI.parse("#{API_BASE}/#{endpoint}")
-    end
+        if response_hash['url']
+          Coveralls::Output.puts("[Coveralls] #{Coveralls::Output.format(response_hash['url'], color: 'underline')}", color: 'cyan')
+        end
 
-    def self.build_client(uri)
-      client = Net::HTTP.new(uri.host, uri.port)
-      client.use_ssl = true if uri.port == 443
-      client.verify_mode = OpenSSL::SSL::VERIFY_NONE
-
-      unless client.respond_to?(:ssl_version=)
-        Net::HTTP.ssl_context_accessor('ssl_version')
+        case response
+        when Net::HTTPServiceUnavailable
+          Coveralls::Output.puts('[Coveralls] API timeout occured, but data should still be processed', color: 'red')
+        when Net::HTTPInternalServerError
+          Coveralls::Output.puts("[Coveralls] API internal error occured, we're on it!", color: 'red')
+        end
       end
 
-      client.ssl_version = 'TLSv1'
+      private
 
-      client
-    end
+      def disable_net_blockers!
+        begin
+          require 'webmock'
 
-    def self.build_request(path, hash)
-      request  = Net::HTTP::Post.new(path)
-      boundary = rand(1_000_000).to_s
+          allow = WebMock::Config.instance.allow || []
+          WebMock::Config.instance.allow = [*allow].push API_HOST
+        rescue LoadError
+        end
 
-      request.body         = build_request_body(hash, boundary)
-      request.content_type = "multipart/form-data, boundary=#{boundary}"
+        begin
+          require 'vcr'
 
-      request
-    end
-
-    def self.build_request_body(hash, boundary)
-      hash = apified_hash(hash)
-      file = hash_to_file(hash)
-
-      "--#{boundary}\r\n" \
-      "Content-Disposition: form-data; name=\"json_file\"; filename=\"#{File.basename(file.path)}\"\r\n" \
-      "Content-Type: text/plain\r\n\r\n" +
-        File.read(file.path) +
-        "\r\n--#{boundary}--\r\n"
-    end
-
-    def self.hash_to_file(hash)
-      file = nil
-      Tempfile.open(['coveralls-upload', 'json']) do |f|
-        f.write(JSON.dump(hash))
-        file = f
+          VCR.send(VCR.version.major < 2 ? :config : :configure) do |c|
+            c.ignore_hosts API_HOST
+          end
+        rescue LoadError
+        end
       end
-      File.new(file.path, 'rb')
-    end
 
-    def self.apified_hash(hash)
-      config = Coveralls::Configuration.configuration
-      if ENV['COVERALLS_DEBUG'] || Coveralls.testing
-        Coveralls::Output.puts '[Coveralls] Submitting with config:', color: 'yellow'
-        output = JSON.pretty_generate(config).gsub(/"repo_token": ?"(.*?)"/, '"repo_token": "[secure]"')
-        Coveralls::Output.puts output, color: 'yellow'
+      def endpoint_to_uri(endpoint)
+        URI.parse("#{API_BASE}/#{endpoint}")
       end
-      hash.merge(config)
+
+      def build_client(uri)
+        client = Net::HTTP.new(uri.host, uri.port)
+        client.use_ssl = true if uri.port == 443
+        client.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+        unless client.respond_to?(:ssl_version=)
+          Net::HTTP.ssl_context_accessor('ssl_version')
+        end
+
+        client.ssl_version = 'TLSv1'
+
+        client
+      end
+
+      def build_request(path, hash)
+        request  = Net::HTTP::Post.new(path)
+        boundary = rand(1_000_000).to_s
+
+        request.body         = build_request_body(hash, boundary)
+        request.content_type = "multipart/form-data, boundary=#{boundary}"
+
+        request
+      end
+
+      def build_request_body(hash, boundary)
+        hash = apified_hash(hash)
+        file = hash_to_file(hash)
+
+        "--#{boundary}\r\n" \
+        "Content-Disposition: form-data; name=\"json_file\"; filename=\"#{File.basename(file.path)}\"\r\n" \
+        "Content-Type: text/plain\r\n\r\n" +
+          File.read(file.path) +
+          "\r\n--#{boundary}--\r\n"
+      end
+
+      def hash_to_file(hash)
+        file = nil
+
+        Tempfile.open(['coveralls-upload', 'json']) do |f|
+          f.write(JSON.dump(hash))
+          file = f
+        end
+
+        File.new(file.path, 'rb')
+      end
+
+      def apified_hash(hash)
+        config = Coveralls::Configuration.configuration
+
+        if ENV['COVERALLS_DEBUG'] || Coveralls.testing
+          Coveralls::Output.puts '[Coveralls] Submitting with config:', color: 'yellow'
+          output = JSON.pretty_generate(config).gsub(/"repo_token": ?"(.*?)"/, '"repo_token": "[secure]"')
+          Coveralls::Output.puts output, color: 'yellow'
+        end
+
+        hash.merge(config)
+      end
     end
   end
 end

--- a/lib/coveralls/command.rb
+++ b/lib/coveralls/command.rb
@@ -12,7 +12,7 @@ module Coveralls
       if File.exist?('.travis.yml')
         cmds = begin
                  YAML.load_file('.travis.yml')['script'] || cmds
-               rescue
+               rescue StandardError
                  cmds
                end
       end

--- a/lib/coveralls/command.rb
+++ b/lib/coveralls/command.rb
@@ -10,7 +10,11 @@ module Coveralls
       cmds = ['bundle exec rake']
 
       if File.exist?('.travis.yml')
-        cmds = YAML.load_file('.travis.yml')['script'] || cmds rescue cmds
+        cmds = begin
+                 YAML.load_file('.travis.yml')['script'] || cmds
+               rescue
+                 cmds
+               end
       end
 
       cmds.each { |cmd| system cmd }

--- a/lib/coveralls/command.rb
+++ b/lib/coveralls/command.rb
@@ -5,19 +5,25 @@ module Coveralls
     desc 'push', 'Runs your test suite and pushes the coverage results to Coveralls.'
     def push
       return unless ensure_can_run_locally!
+
       ENV['COVERALLS_RUN_LOCALLY'] = 'true'
       cmds = ['bundle exec rake']
+
       if File.exist?('.travis.yml')
         cmds = YAML.load_file('.travis.yml')['script'] || cmds rescue cmds
       end
+
       cmds.each { |cmd| system cmd }
+
       ENV['COVERALLS_RUN_LOCALLY'] = nil
     end
 
     desc 'report', 'Runs your test suite locally and displays coverage statistics.'
     def report
       ENV['COVERALLS_NOISY'] = 'true'
+
       exec 'bundle exec rake'
+
       ENV['COVERALLS_NOISY'] = nil
     end
 
@@ -43,8 +49,11 @@ module Coveralls
 
     private
 
+    def config
+      Coveralls::Configuration.configuration
+    end
+
     def open_token_based_url(url)
-      config = Coveralls::Configuration.configuration
       if config[:repo_token]
         url = url.gsub('%@', config[:repo_token])
         `open #{url}`
@@ -54,13 +63,13 @@ module Coveralls
     end
 
     def ensure_can_run_locally!
-      config = Coveralls::Configuration.configuration
       if config[:repo_token].nil?
         Coveralls::Output.puts 'Coveralls cannot run locally because no repo_secret_token is set in .coveralls.yml', color: 'red'
         Coveralls::Output.puts 'Please try again when you get your act together.', color: 'red'
 
         return false
       end
+
       true
     end
   end

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -187,7 +187,7 @@ module Coveralls
 
         hash
 
-      rescue Exception => e
+      rescue StandardError => e
         Coveralls::Output.puts 'Coveralls git error:', color: 'red'
         Coveralls::Output.puts e.to_s, color: 'red'
         nil

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -30,25 +30,25 @@ module Coveralls
         end
 
         if ENV['TRAVIS']
-          set_service_params_for_travis(config, yml ? yml['service_name'] : nil)
+          define_service_params_for_travis(config, yml ? yml['service_name'] : nil)
         elsif ENV['CIRCLECI']
-          set_service_params_for_circleci(config)
+          define_service_params_for_circleci(config)
         elsif ENV['SEMAPHORE']
-          set_service_params_for_semaphore(config)
+          define_service_params_for_semaphore(config)
         elsif ENV['JENKINS_URL'] || ENV['JENKINS_HOME']
-          set_service_params_for_jenkins(config)
+          define_service_params_for_jenkins(config)
         elsif ENV['APPVEYOR']
-          set_service_params_for_appveyor(config)
+          define_service_params_for_appveyor(config)
         elsif ENV['TDDIUM']
-          set_service_params_for_tddium(config)
+          define_service_params_for_tddium(config)
         elsif ENV['GITLAB_CI']
-          set_service_params_for_gitlab(config)
+          define_service_params_for_gitlab(config)
         elsif ENV['COVERALLS_RUN_LOCALLY'] || Coveralls.testing
-          set_service_params_for_coveralls_local(config)
+          define_service_params_for_coveralls_local(config)
         end
 
         # standardized env vars
-        set_standard_service_params_for_generic_ci(config)
+        define_standard_service_params_for_generic_ci(config)
 
         if service_name = ENV['COVERALLS_SERVICE_NAME']
           config[:service_name] = service_name
@@ -57,14 +57,14 @@ module Coveralls
         config
       end
 
-      def set_service_params_for_travis(config, service_name)
+      def define_service_params_for_travis(config, service_name)
         config[:service_job_id] = ENV['TRAVIS_JOB_ID']
         config[:service_pull_request] = ENV['TRAVIS_PULL_REQUEST'] unless ENV['TRAVIS_PULL_REQUEST'] == 'false'
         config[:service_name]   = service_name || 'travis-ci'
         config[:service_branch] = ENV['TRAVIS_BRANCH']
       end
 
-      def set_service_params_for_circleci(config)
+      def define_service_params_for_circleci(config)
         config[:service_name]         = 'circleci'
         config[:service_number]       = ENV['CIRCLE_BUILD_NUM']
         config[:service_pull_request] = (ENV['CI_PULL_REQUEST'] || '')[/(\d+)$/, 1]
@@ -72,20 +72,20 @@ module Coveralls
         config[:service_job_number]   = ENV['CIRCLE_NODE_INDEX']
       end
 
-      def set_service_params_for_semaphore(config)
+      def define_service_params_for_semaphore(config)
         config[:service_name]         = 'semaphore'
         config[:service_number]       = ENV['SEMAPHORE_BUILD_NUMBER']
         config[:service_pull_request] = ENV['PULL_REQUEST_NUMBER']
       end
 
-      def set_service_params_for_jenkins(config)
+      def define_service_params_for_jenkins(config)
         config[:service_name]   = 'jenkins'
         config[:service_number] = ENV['BUILD_NUMBER']
         config[:service_branch] = ENV['BRANCH_NAME']
         config[:service_pull_request] = ENV['ghprbPullId']
       end
 
-      def set_service_params_for_appveyor(config)
+      def define_service_params_for_appveyor(config)
         config[:service_name]   = 'appveyor'
         config[:service_number] = ENV['APPVEYOR_BUILD_VERSION']
         config[:service_branch] = ENV['APPVEYOR_REPO_BRANCH']
@@ -94,7 +94,7 @@ module Coveralls
         config[:service_build_url] = format('https://ci.appveyor.com/project/%s/build/%s', repo_name, config[:service_number])
       end
 
-      def set_service_params_for_tddium(config)
+      def define_service_params_for_tddium(config)
         config[:service_name]         = 'tddium'
         config[:service_number]       = ENV['TDDIUM_SESSION_ID']
         config[:service_job_number]   = ENV['TDDIUM_TID']
@@ -103,7 +103,7 @@ module Coveralls
         config[:service_build_url]    = "https://ci.solanolabs.com/reports/#{ENV['TDDIUM_SESSION_ID']}"
       end
 
-      def set_service_params_for_gitlab(config)
+      def define_service_params_for_gitlab(config)
         config[:service_name]         = 'gitlab-ci'
         config[:service_job_number]   = ENV['CI_BUILD_NAME']
         config[:service_job_id]       = ENV['CI_BUILD_ID']
@@ -111,13 +111,13 @@ module Coveralls
         config[:commit_sha]           = ENV['CI_BUILD_REF']
       end
 
-      def set_service_params_for_coveralls_local(config)
+      def define_service_params_for_coveralls_local(config)
         config[:service_job_id]     = nil
         config[:service_name]       = 'coveralls-ruby'
         config[:service_event_type] = 'manual'
       end
 
-      def set_standard_service_params_for_generic_ci(config)
+      def define_standard_service_params_for_generic_ci(config)
         config[:service_name]         ||= ENV['CI_NAME']
         config[:service_number]       ||= ENV['CI_BUILD_NUMBER']
         config[:service_job_id]       ||= ENV['CI_JOB_ID']

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -220,7 +220,6 @@ module Coveralls
         hash
       end
 
-
       private
 
       def circleci_env_hash

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -3,227 +3,257 @@ require 'securerandom'
 
 module Coveralls
   module Configuration
-    def self.configuration
-      config = {
-        environment: relevant_env,
-        git: git
-      }
-      yml = yaml_config
-      if yml
-        config[:configuration] = yml
-        config[:repo_token] = yml['repo_token'] || yml['repo_secret_token']
-      end
-      if ENV['COVERALLS_REPO_TOKEN']
-        config[:repo_token] = ENV['COVERALLS_REPO_TOKEN']
-      end
-      if ENV['COVERALLS_PARALLEL'] && ENV['COVERALLS_PARALLEL'] != 'false'
-        config[:parallel] = true
-      end
-      if ENV['COVERALLS_FLAG_NAME']
-        config[:flag_name] = ENV['COVERALLS_FLAG_NAME']
-      end
-      if ENV['TRAVIS']
-        set_service_params_for_travis(config, yml ? yml['service_name'] : nil)
-      elsif ENV['CIRCLECI']
-        set_service_params_for_circleci(config)
-      elsif ENV['SEMAPHORE']
-        set_service_params_for_semaphore(config)
-      elsif ENV['JENKINS_URL'] || ENV['JENKINS_HOME']
-        set_service_params_for_jenkins(config)
-      elsif ENV['APPVEYOR']
-        set_service_params_for_appveyor(config)
-      elsif ENV['TDDIUM']
-        set_service_params_for_tddium(config)
-      elsif ENV['GITLAB_CI']
-        set_service_params_for_gitlab(config)
-      elsif ENV['COVERALLS_RUN_LOCALLY'] || Coveralls.testing
-        set_service_params_for_coveralls_local(config)
-      end
-
-      # standardized env vars
-      set_standard_service_params_for_generic_ci(config)
-
-      if service_name = ENV['COVERALLS_SERVICE_NAME']
-        config[:service_name] = service_name
-      end
-
-      config
-    end
-
-    def self.set_service_params_for_travis(config, service_name)
-      config[:service_job_id] = ENV['TRAVIS_JOB_ID']
-      config[:service_pull_request] = ENV['TRAVIS_PULL_REQUEST'] unless ENV['TRAVIS_PULL_REQUEST'] == 'false'
-      config[:service_name]   = service_name || 'travis-ci'
-      config[:service_branch] = ENV['TRAVIS_BRANCH']
-    end
-
-    def self.set_service_params_for_circleci(config)
-      config[:service_name]         = 'circleci'
-      config[:service_number]       = ENV['CIRCLE_BUILD_NUM']
-      config[:service_pull_request] = (ENV['CI_PULL_REQUEST'] || '')[/(\d+)$/, 1]
-      config[:parallel]             = ENV['CIRCLE_NODE_TOTAL'].to_i > 1
-      config[:service_job_number]   = ENV['CIRCLE_NODE_INDEX']
-    end
-
-    def self.set_service_params_for_semaphore(config)
-      config[:service_name]         = 'semaphore'
-      config[:service_number]       = ENV['SEMAPHORE_BUILD_NUMBER']
-      config[:service_pull_request] = ENV['PULL_REQUEST_NUMBER']
-    end
-
-    def self.set_service_params_for_jenkins(config)
-      config[:service_name]   = 'jenkins'
-      config[:service_number] = ENV['BUILD_NUMBER']
-      config[:service_branch] = ENV['BRANCH_NAME']
-      config[:service_pull_request] = ENV['ghprbPullId']
-    end
-
-    def self.set_service_params_for_appveyor(config)
-      config[:service_name]   = 'appveyor'
-      config[:service_number] = ENV['APPVEYOR_BUILD_VERSION']
-      config[:service_branch] = ENV['APPVEYOR_REPO_BRANCH']
-      config[:commit_sha] = ENV['APPVEYOR_REPO_COMMIT']
-      repo_name = ENV['APPVEYOR_REPO_NAME']
-      config[:service_build_url] = format('https://ci.appveyor.com/project/%s/build/%s', repo_name, config[:service_number])
-    end
-
-    def self.set_service_params_for_tddium(config)
-      config[:service_name]         = 'tddium'
-      config[:service_number]       = ENV['TDDIUM_SESSION_ID']
-      config[:service_job_number]   = ENV['TDDIUM_TID']
-      config[:service_pull_request] = ENV['TDDIUM_PR_ID']
-      config[:service_branch]       = ENV['TDDIUM_CURRENT_BRANCH']
-      config[:service_build_url]    = "https://ci.solanolabs.com/reports/#{ENV['TDDIUM_SESSION_ID']}"
-    end
-
-    def self.set_service_params_for_gitlab(config)
-      config[:service_name]         = 'gitlab-ci'
-      config[:service_job_number]   = ENV['CI_BUILD_NAME']
-      config[:service_job_id]       = ENV['CI_BUILD_ID']
-      config[:service_branch]       = ENV['CI_BUILD_REF_NAME']
-      config[:commit_sha]           = ENV['CI_BUILD_REF']
-    end
-
-    def self.set_service_params_for_coveralls_local(config)
-      config[:service_job_id]     = nil
-      config[:service_name]       = 'coveralls-ruby'
-      config[:service_event_type] = 'manual'
-    end
-
-    def self.set_standard_service_params_for_generic_ci(config)
-      config[:service_name]         ||= ENV['CI_NAME']
-      config[:service_number]       ||= ENV['CI_BUILD_NUMBER']
-      config[:service_job_id]       ||= ENV['CI_JOB_ID']
-      config[:service_build_url]    ||= ENV['CI_BUILD_URL']
-      config[:service_branch]       ||= ENV['CI_BRANCH']
-      config[:service_pull_request] ||= (ENV['CI_PULL_REQUEST'] || '')[/(\d+)$/, 1]
-    end
-
-    def self.yaml_config
-      if configuration_path && File.exist?(configuration_path)
-        YAML.load_file(configuration_path)
-      end
-    end
-
-    def self.configuration_path
-      File.expand_path(File.join(root, '.coveralls.yml')) if root
-    end
-
-    def self.root
-      pwd
-    end
-
-    def self.pwd
-      Dir.pwd
-    end
-
-    def self.simplecov_root
-      if defined?(::SimpleCov)
-        ::SimpleCov.root
-      end
-    end
-
-    def self.rails_root
-      Rails.root.to_s
-    rescue StandardError
-      nil
-    end
-
-    def self.git
-      hash = {}
-
-      Dir.chdir(root) do
-        hash[:head] = {
-          id: ENV.fetch('GIT_ID', `git log -1 --pretty=format:'%H'`),
-          author_name: ENV.fetch('GIT_AUTHOR_NAME', `git log -1 --pretty=format:'%aN'`),
-          author_email: ENV.fetch('GIT_AUTHOR_EMAIL', `git log -1 --pretty=format:'%ae'`),
-          committer_name: ENV.fetch('GIT_COMMITTER_NAME', `git log -1 --pretty=format:'%cN'`),
-          committer_email: ENV.fetch('GIT_COMMITTER_EMAIL', `git log -1 --pretty=format:'%ce'`),
-          message: ENV.fetch('GIT_MESSAGE', `git log -1 --pretty=format:'%s'`)
+    class << self
+      def configuration
+        config = {
+          environment: relevant_env,
+          git: git
         }
 
-        # Branch
-        hash[:branch] = ENV.fetch('GIT_BRANCH', `git rev-parse --abbrev-ref HEAD`)
+        yml = yaml_config
 
-        # Remotes
-        remotes = nil
-        begin
-          remotes = `git remote -v`.split(/\n/).map do |remote|
-            splits = remote.split(' ').compact
-            { name: splits[0], url: splits[1] }
-          end.uniq
-        rescue StandardError
+        if yml
+          config[:configuration] = yml
+          config[:repo_token] = yml['repo_token'] || yml['repo_secret_token']
         end
-        hash[:remotes] = remotes
-      end
 
-      hash
+        if ENV['COVERALLS_REPO_TOKEN']
+          config[:repo_token] = ENV['COVERALLS_REPO_TOKEN']
+        end
 
-    rescue Exception => e
-      Coveralls::Output.puts 'Coveralls git error:', color: 'red'
-      Coveralls::Output.puts e.to_s, color: 'red'
-      nil
-    end
+        if ENV['COVERALLS_PARALLEL'] && ENV['COVERALLS_PARALLEL'] != 'false'
+          config[:parallel] = true
+        end
 
-    def self.relevant_env
-      hash = {
-        pwd: pwd,
-        rails_root: rails_root,
-        simplecov_root: simplecov_root,
-        gem_version: VERSION
-      }
+        if ENV['COVERALLS_FLAG_NAME']
+          config[:flag_name] = ENV['COVERALLS_FLAG_NAME']
+        end
 
-      hash.merge! begin
         if ENV['TRAVIS']
-          {
-            travis_job_id: ENV['TRAVIS_JOB_ID'],
-            travis_pull_request: ENV['TRAVIS_PULL_REQUEST'],
-            branch: ENV['TRAVIS_BRANCH']
-          }
+          set_service_params_for_travis(config, yml ? yml['service_name'] : nil)
         elsif ENV['CIRCLECI']
-          {
-            circleci_build_num: ENV['CIRCLE_BUILD_NUM'],
-            branch: ENV['CIRCLE_BRANCH'],
-            commit_sha: ENV['CIRCLE_SHA1']
-          }
-        elsif ENV['JENKINS_URL']
-          {
-            jenkins_build_num: ENV['BUILD_NUMBER'],
-            jenkins_build_url: ENV['BUILD_URL'],
-            branch: ENV['GIT_BRANCH'],
-            commit_sha: ENV['GIT_COMMIT']
-          }
+          set_service_params_for_circleci(config)
         elsif ENV['SEMAPHORE']
-          {
-            branch: ENV['BRANCH_NAME'],
-            commit_sha: ENV['REVISION']
-          }
-        else
-          {}
+          set_service_params_for_semaphore(config)
+        elsif ENV['JENKINS_URL'] || ENV['JENKINS_HOME']
+          set_service_params_for_jenkins(config)
+        elsif ENV['APPVEYOR']
+          set_service_params_for_appveyor(config)
+        elsif ENV['TDDIUM']
+          set_service_params_for_tddium(config)
+        elsif ENV['GITLAB_CI']
+          set_service_params_for_gitlab(config)
+        elsif ENV['COVERALLS_RUN_LOCALLY'] || Coveralls.testing
+          set_service_params_for_coveralls_local(config)
         end
+
+        # standardized env vars
+        set_standard_service_params_for_generic_ci(config)
+
+        if service_name = ENV['COVERALLS_SERVICE_NAME']
+          config[:service_name] = service_name
+        end
+
+        config
       end
 
-      hash
+      def set_service_params_for_travis(config, service_name)
+        config[:service_job_id] = ENV['TRAVIS_JOB_ID']
+        config[:service_pull_request] = ENV['TRAVIS_PULL_REQUEST'] unless ENV['TRAVIS_PULL_REQUEST'] == 'false'
+        config[:service_name]   = service_name || 'travis-ci'
+        config[:service_branch] = ENV['TRAVIS_BRANCH']
+      end
+
+      def set_service_params_for_circleci(config)
+        config[:service_name]         = 'circleci'
+        config[:service_number]       = ENV['CIRCLE_BUILD_NUM']
+        config[:service_pull_request] = (ENV['CI_PULL_REQUEST'] || '')[/(\d+)$/, 1]
+        config[:parallel]             = ENV['CIRCLE_NODE_TOTAL'].to_i > 1
+        config[:service_job_number]   = ENV['CIRCLE_NODE_INDEX']
+      end
+
+      def set_service_params_for_semaphore(config)
+        config[:service_name]         = 'semaphore'
+        config[:service_number]       = ENV['SEMAPHORE_BUILD_NUMBER']
+        config[:service_pull_request] = ENV['PULL_REQUEST_NUMBER']
+      end
+
+      def set_service_params_for_jenkins(config)
+        config[:service_name]   = 'jenkins'
+        config[:service_number] = ENV['BUILD_NUMBER']
+        config[:service_branch] = ENV['BRANCH_NAME']
+        config[:service_pull_request] = ENV['ghprbPullId']
+      end
+
+      def set_service_params_for_appveyor(config)
+        config[:service_name]   = 'appveyor'
+        config[:service_number] = ENV['APPVEYOR_BUILD_VERSION']
+        config[:service_branch] = ENV['APPVEYOR_REPO_BRANCH']
+        config[:commit_sha] = ENV['APPVEYOR_REPO_COMMIT']
+        repo_name = ENV['APPVEYOR_REPO_NAME']
+        config[:service_build_url] = format('https://ci.appveyor.com/project/%s/build/%s', repo_name, config[:service_number])
+      end
+
+      def set_service_params_for_tddium(config)
+        config[:service_name]         = 'tddium'
+        config[:service_number]       = ENV['TDDIUM_SESSION_ID']
+        config[:service_job_number]   = ENV['TDDIUM_TID']
+        config[:service_pull_request] = ENV['TDDIUM_PR_ID']
+        config[:service_branch]       = ENV['TDDIUM_CURRENT_BRANCH']
+        config[:service_build_url]    = "https://ci.solanolabs.com/reports/#{ENV['TDDIUM_SESSION_ID']}"
+      end
+
+      def set_service_params_for_gitlab(config)
+        config[:service_name]         = 'gitlab-ci'
+        config[:service_job_number]   = ENV['CI_BUILD_NAME']
+        config[:service_job_id]       = ENV['CI_BUILD_ID']
+        config[:service_branch]       = ENV['CI_BUILD_REF_NAME']
+        config[:commit_sha]           = ENV['CI_BUILD_REF']
+      end
+
+      def set_service_params_for_coveralls_local(config)
+        config[:service_job_id]     = nil
+        config[:service_name]       = 'coveralls-ruby'
+        config[:service_event_type] = 'manual'
+      end
+
+      def set_standard_service_params_for_generic_ci(config)
+        config[:service_name]         ||= ENV['CI_NAME']
+        config[:service_number]       ||= ENV['CI_BUILD_NUMBER']
+        config[:service_job_id]       ||= ENV['CI_JOB_ID']
+        config[:service_build_url]    ||= ENV['CI_BUILD_URL']
+        config[:service_branch]       ||= ENV['CI_BRANCH']
+        config[:service_pull_request] ||= (ENV['CI_PULL_REQUEST'] || '')[/(\d+)$/, 1]
+      end
+
+      def yaml_config
+        return unless configuration_path && File.exist?(configuration_path)
+
+        YAML.load_file(configuration_path)
+      end
+
+      def configuration_path
+        return unless root
+
+        File.expand_path(File.join(root, '.coveralls.yml'))
+      end
+
+      def root
+        pwd
+      end
+
+      def pwd
+        Dir.pwd
+      end
+
+      def simplecov_root
+        return unless defined?(::SimpleCov)
+
+        ::SimpleCov.root
+      end
+
+      def rails_root
+        Rails.root.to_s
+      rescue StandardError
+        nil
+      end
+
+      def git
+        hash = {}
+
+        Dir.chdir(root) do
+          hash[:head] = {
+            id: ENV.fetch('GIT_ID', `git log -1 --pretty=format:'%H'`),
+            author_name: ENV.fetch('GIT_AUTHOR_NAME', `git log -1 --pretty=format:'%aN'`),
+            author_email: ENV.fetch('GIT_AUTHOR_EMAIL', `git log -1 --pretty=format:'%ae'`),
+            committer_name: ENV.fetch('GIT_COMMITTER_NAME', `git log -1 --pretty=format:'%cN'`),
+            committer_email: ENV.fetch('GIT_COMMITTER_EMAIL', `git log -1 --pretty=format:'%ce'`),
+            message: ENV.fetch('GIT_MESSAGE', `git log -1 --pretty=format:'%s'`)
+          }
+
+          # Branch
+          hash[:branch] = ENV.fetch('GIT_BRANCH', `git rev-parse --abbrev-ref HEAD`)
+
+          # Remotes
+          remotes = nil
+          begin
+            remotes = `git remote -v`.split(/\n/).map do |remote|
+              splits = remote.split(' ').compact
+              { name: splits[0], url: splits[1] }
+            end.uniq
+          rescue StandardError
+          end
+
+          hash[:remotes] = remotes
+        end
+
+        hash
+
+      rescue Exception => e
+        Coveralls::Output.puts 'Coveralls git error:', color: 'red'
+        Coveralls::Output.puts e.to_s, color: 'red'
+        nil
+      end
+
+      def relevant_env
+        hash = {
+          pwd: pwd,
+          rails_root: rails_root,
+          simplecov_root: simplecov_root,
+          gem_version: VERSION
+        }
+
+        hash.merge! begin
+          if ENV['TRAVIS']
+            travis_env_hash
+          elsif ENV['CIRCLECI']
+            circleci_env_hash
+          elsif ENV['JENKINS_URL']
+            jenkins_env_hash
+          elsif ENV['SEMAPHORE']
+            semaphore_env_hash
+          else
+            {}
+          end
+        end
+
+        hash
+      end
+
+
+      private
+
+      def circleci_env_hash
+        {
+          circleci_build_num: ENV['CIRCLE_BUILD_NUM'],
+          branch: ENV['CIRCLE_BRANCH'],
+          commit_sha: ENV['CIRCLE_SHA1']
+        }
+      end
+
+      def jenkins_env_hash
+        {
+          jenkins_build_num: ENV['BUILD_NUMBER'],
+          jenkins_build_url: ENV['BUILD_URL'],
+          branch: ENV['GIT_BRANCH'],
+          commit_sha: ENV['GIT_COMMIT']
+        }
+      end
+
+      def semaphore_env_hash
+        {
+          branch: ENV['BRANCH_NAME'],
+          commit_sha: ENV['REVISION']
+        }
+      end
+
+      def travis_env_hash
+        {
+          travis_job_id: ENV['TRAVIS_JOB_ID'],
+          travis_pull_request: ENV['TRAVIS_PULL_REQUEST'],
+          branch: ENV['TRAVIS_BRANCH']
+        }
+      end
     end
   end
 end

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -186,7 +186,6 @@ module Coveralls
         end
 
         hash
-
       rescue StandardError => e
         Coveralls::Output.puts 'Coveralls git error:', color: 'red'
         Coveralls::Output.puts e.to_s, color: 'red'

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -49,11 +49,9 @@ module Coveralls
 
         # standardized env vars
         define_standard_service_params_for_generic_ci(config)
+        service_name = ENV['COVERALLS_SERVICE_NAME']
 
-        if service_name = ENV['COVERALLS_SERVICE_NAME']
-          config[:service_name] = service_name
-        end
-
+        config[:service_name] = service_name
         config
       end
 

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -179,7 +179,9 @@ module Coveralls
               splits = remote.split(' ').compact
               { name: splits[0], url: splits[1] }
             end.uniq
-          rescue StandardError
+          rescue StandardError => error
+            # TODO: Add error action
+            puts error.message
           end
 
           hash[:remotes] = remotes

--- a/lib/coveralls/output.rb
+++ b/lib/coveralls/output.rb
@@ -63,10 +63,10 @@ module Coveralls
       unless no_color?
         require 'term/ansicolor'
         options[:color]&.split(/\s/)&.reverse_each do |color|
-            if Term::ANSIColor.respond_to?(color.to_sym)
-              string = Term::ANSIColor.send(color.to_sym, string)
-            end
-          end
+          next unless Term::ANSIColor.respond_to?(color.to_sym)
+
+          string = Term::ANSIColor.send(color.to_sym, string)
+        end
       end
       string
     end

--- a/lib/coveralls/output.rb
+++ b/lib/coveralls/output.rb
@@ -34,6 +34,7 @@ module Coveralls
   module Output
     attr_accessor :silent, :no_color
     attr_writer :output
+
     extend self
 
     def output
@@ -85,6 +86,7 @@ module Coveralls
     # Returns nil.
     def puts(string, options = {})
       return if silent?
+
       (options[:output] || output).puts format(string, options)
     end
 
@@ -102,6 +104,7 @@ module Coveralls
     # Returns nil.
     def print(string, options = {})
       return if silent?
+
       (options[:output] || output).print format(string, options)
     end
 

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -72,7 +72,7 @@ module Coveralls
 
         true
 
-      rescue Exception => error
+      rescue StandardError => error
         display_error error
       end
 

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -54,9 +54,8 @@ module Coveralls
 
       def format(result)
         unless Coveralls.should_run?
-          if Coveralls.noisy?
-            display_result result
-          end
+          display_result result if Coveralls.noisy?
+          
           return
         end
 

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -92,7 +92,11 @@ module Coveralls
       end
 
       def output_message(result)
-        "Coverage is at #{result.covered_percent.round(2) rescue result.covered_percent.round}%.\nCoverage report sent to Coveralls."
+        "Coverage is at #{begin
+                            result.covered_percent.round(2)
+                          rescue
+                            result.covered_percent.round
+                          end}%.\nCoverage report sent to Coveralls."
       end
 
       def short_filename(filename)

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -71,7 +71,6 @@ module Coveralls
         Coveralls::Output.puts output_message result
 
         true
-
       rescue StandardError => error
         display_error error
       end

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -94,7 +94,7 @@ module Coveralls
       def output_message(result)
         "Coverage is at #{begin
                             result.covered_percent.round(2)
-                          rescue
+                          rescue StandardError
                             result.covered_percent.round
                           end}%.\nCoverage report sent to Coveralls."
       end

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -10,6 +10,7 @@ module Coveralls
         else
           Coveralls::Output.puts '[Coveralls] There are no covered files.', color: 'yellow'
         end
+
         result.files.each do |f|
           Coveralls::Output.print '  * '
           Coveralls::Output.print short_filename(f.filename).to_s, color: 'cyan'
@@ -24,6 +25,7 @@ module Coveralls
           end
           Coveralls::Output.puts ''
         end
+
         true
       end
 
@@ -49,6 +51,7 @@ module Coveralls
 
           source_files << properties
         end
+
         source_files
       end
 
@@ -77,12 +80,15 @@ module Coveralls
         Coveralls::Output.puts 'Coveralls encountered an exception:', color: 'red'
         Coveralls::Output.puts error.class.to_s, color: 'red'
         Coveralls::Output.puts error.message, color: 'red'
+
         error.backtrace&.each do |line|
           Coveralls::Output.puts line, color: 'red'
         end
+
         if error.respond_to?(:response) && error.response
           Coveralls::Output.puts error.response.to_s, color: 'red'
         end
+
         false
       end
 

--- a/lib/coveralls/simplecov.rb
+++ b/lib/coveralls/simplecov.rb
@@ -55,7 +55,7 @@ module Coveralls
       def format(result)
         unless Coveralls.should_run?
           display_result result if Coveralls.noisy?
-          
+
           return
         end
 
@@ -69,19 +69,19 @@ module Coveralls
 
         true
 
-      rescue Exception => e
-        display_error e
+      rescue Exception => error
+        display_error error
       end
 
-      def display_error(e)
+      def display_error(error)
         Coveralls::Output.puts 'Coveralls encountered an exception:', color: 'red'
-        Coveralls::Output.puts e.class.to_s, color: 'red'
-        Coveralls::Output.puts e.message, color: 'red'
-        e.backtrace&.each do |line|
+        Coveralls::Output.puts error.class.to_s, color: 'red'
+        Coveralls::Output.puts error.message, color: 'red'
+        error.backtrace&.each do |line|
           Coveralls::Output.puts line, color: 'red'
         end
-        if e.respond_to?(:response) && e.response
-          Coveralls::Output.puts e.response.to_s, color: 'red'
+        if error.respond_to?(:response) && error.response
+          Coveralls::Output.puts error.response.to_s, color: 'red'
         end
         false
       end

--- a/spec/coveralls/configuration_spec.rb
+++ b/spec/coveralls/configuration_spec.rb
@@ -87,12 +87,12 @@ describe Coveralls::Configuration do
         end
 
         it 'should set service parameters for this service and no other' do
-          Coveralls::Configuration.should_receive(:set_service_params_for_travis).with(anything, anything)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_circleci)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_semaphore)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_jenkins)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_coveralls_local)
-          Coveralls::Configuration.should_receive(:set_standard_service_params_for_generic_ci)
+          Coveralls::Configuration.should_receive(:define_service_params_for_travis).with(anything, anything)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_circleci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_semaphore)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_jenkins)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_coveralls_local)
+          Coveralls::Configuration.should_receive(:define_standard_service_params_for_generic_ci)
           Coveralls::Configuration.configuration
         end
       end
@@ -103,12 +103,12 @@ describe Coveralls::Configuration do
         end
 
         it 'should set service parameters for this service and no other' do
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_travis)
-          Coveralls::Configuration.should_receive(:set_service_params_for_circleci)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_semaphore)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_jenkins)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_coveralls_local)
-          Coveralls::Configuration.should_receive(:set_standard_service_params_for_generic_ci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_travis)
+          Coveralls::Configuration.should_receive(:define_service_params_for_circleci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_semaphore)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_jenkins)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_coveralls_local)
+          Coveralls::Configuration.should_receive(:define_standard_service_params_for_generic_ci)
           Coveralls::Configuration.configuration
         end
       end
@@ -119,12 +119,12 @@ describe Coveralls::Configuration do
         end
 
         it 'should set service parameters for this service and no other' do
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_travis)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_circleci)
-          Coveralls::Configuration.should_receive(:set_service_params_for_semaphore)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_jenkins)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_coveralls_local)
-          Coveralls::Configuration.should_receive(:set_standard_service_params_for_generic_ci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_travis)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_circleci)
+          Coveralls::Configuration.should_receive(:define_service_params_for_semaphore)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_jenkins)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_coveralls_local)
+          Coveralls::Configuration.should_receive(:define_standard_service_params_for_generic_ci)
           Coveralls::Configuration.configuration
         end
       end
@@ -135,12 +135,12 @@ describe Coveralls::Configuration do
         end
 
         it 'should set service parameters for this service and no other' do
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_travis)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_circleci)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_semaphore)
-          Coveralls::Configuration.should_receive(:set_service_params_for_jenkins)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_coveralls_local)
-          Coveralls::Configuration.should_receive(:set_standard_service_params_for_generic_ci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_travis)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_circleci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_semaphore)
+          Coveralls::Configuration.should_receive(:define_service_params_for_jenkins)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_coveralls_local)
+          Coveralls::Configuration.should_receive(:define_standard_service_params_for_generic_ci)
           Coveralls::Configuration.configuration
         end
       end
@@ -151,12 +151,12 @@ describe Coveralls::Configuration do
         end
 
         it 'should set service parameters for this service and no other' do
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_travis)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_circleci)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_semaphore)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_jenkins)
-          Coveralls::Configuration.should_receive(:set_service_params_for_coveralls_local)
-          Coveralls::Configuration.should_receive(:set_standard_service_params_for_generic_ci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_travis)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_circleci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_semaphore)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_jenkins)
+          Coveralls::Configuration.should_receive(:define_service_params_for_coveralls_local)
+          Coveralls::Configuration.should_receive(:define_standard_service_params_for_generic_ci)
           Coveralls::Configuration.configuration
         end
       end
@@ -167,19 +167,19 @@ describe Coveralls::Configuration do
         end
 
         it 'should set service parameters for this service and no other' do
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_travis)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_circleci)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_semaphore)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_jenkins)
-          Coveralls::Configuration.should_not_receive(:set_service_params_for_coveralls_local)
-          Coveralls::Configuration.should_receive(:set_standard_service_params_for_generic_ci).with(anything)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_travis)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_circleci)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_semaphore)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_jenkins)
+          Coveralls::Configuration.should_not_receive(:define_service_params_for_coveralls_local)
+          Coveralls::Configuration.should_receive(:define_standard_service_params_for_generic_ci).with(anything)
           Coveralls::Configuration.configuration
         end
       end
     end
   end
 
-  describe '.set_service_params_for_travis' do
+  describe '.define_service_params_for_travis' do
     let(:travis_job_id) { SecureRandom.hex(4) }
     before do
       ENV.stub(:[]).with('TRAVIS_JOB_ID').and_return(travis_job_id)
@@ -187,25 +187,25 @@ describe Coveralls::Configuration do
 
     it 'should set the service_job_id' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_travis(config, nil)
+      Coveralls::Configuration.define_service_params_for_travis(config, nil)
       config[:service_job_id].should eq(travis_job_id)
     end
 
     it 'should set the service_name to travis-ci by default' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_travis(config, nil)
+      Coveralls::Configuration.define_service_params_for_travis(config, nil)
       config[:service_name].should eq('travis-ci')
     end
 
     it 'should set the service_name to a value if one is passed in' do
       config = {}
       random_name = SecureRandom.hex(4)
-      Coveralls::Configuration.set_service_params_for_travis(config, random_name)
+      Coveralls::Configuration.define_service_params_for_travis(config, random_name)
       config[:service_name].should eq(random_name)
     end
   end
 
-  describe '.set_service_params_for_circleci' do
+  describe '.define_service_params_for_circleci' do
     let(:circle_build_num) { SecureRandom.hex(4) }
     before do
       ENV.stub(:[]).with('CIRCLE_BUILD_NUM').and_return(circle_build_num)
@@ -213,13 +213,13 @@ describe Coveralls::Configuration do
 
     it 'should set the expected parameters' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_circleci(config)
+      Coveralls::Configuration.define_service_params_for_circleci(config)
       config[:service_name].should eq('circleci')
       config[:service_number].should eq(circle_build_num)
     end
   end
 
-  describe '.set_service_params_for_gitlab' do
+  describe '.define_service_params_for_gitlab' do
     let(:commit_sha) { SecureRandom.hex(32) }
     let(:service_job_number) { 'spec:one' }
     let(:service_job_id) { 1234 }
@@ -234,7 +234,7 @@ describe Coveralls::Configuration do
 
     it 'should set the expected parameters' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_gitlab(config)
+      Coveralls::Configuration.define_service_params_for_gitlab(config)
       config[:service_name].should eq('gitlab-ci')
       config[:service_job_number].should eq(service_job_number)
       config[:service_job_id].should eq(service_job_id)
@@ -243,7 +243,7 @@ describe Coveralls::Configuration do
     end
   end
 
-  describe '.set_service_params_for_semaphore' do
+  describe '.define_service_params_for_semaphore' do
     let(:semaphore_build_num) { SecureRandom.hex(4) }
     before do
       ENV.stub(:[]).with('SEMAPHORE_BUILD_NUMBER').and_return(semaphore_build_num)
@@ -251,13 +251,13 @@ describe Coveralls::Configuration do
 
     it 'should set the expected parameters' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_semaphore(config)
+      Coveralls::Configuration.define_service_params_for_semaphore(config)
       config[:service_name].should eq('semaphore')
       config[:service_number].should eq(semaphore_build_num)
     end
   end
 
-  describe '.set_service_params_for_jenkins' do
+  describe '.define_service_params_for_jenkins' do
     let(:service_pull_request) { '1234' }
     let(:build_num) { SecureRandom.hex(4) }
     before do
@@ -267,25 +267,25 @@ describe Coveralls::Configuration do
 
     it 'should set the expected parameters' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_jenkins(config)
-      Coveralls::Configuration.set_standard_service_params_for_generic_ci(config)
+      Coveralls::Configuration.define_service_params_for_jenkins(config)
+      Coveralls::Configuration.define_standard_service_params_for_generic_ci(config)
       config[:service_name].should eq('jenkins')
       config[:service_number].should eq(build_num)
       config[:service_pull_request].should eq(service_pull_request)
     end
   end
 
-  describe '.set_service_params_for_coveralls_local' do
+  describe '.define_service_params_for_coveralls_local' do
     it 'should set the expected parameters' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_coveralls_local(config)
+      Coveralls::Configuration.define_service_params_for_coveralls_local(config)
       config[:service_name].should eq('coveralls-ruby')
       config[:service_job_id].should be_nil
       config[:service_event_type].should eq('manual')
     end
   end
 
-  describe '.set_service_params_for_generic_ci' do
+  describe '.define_service_params_for_generic_ci' do
     let(:service_name) { SecureRandom.hex(4) }
     let(:service_number) { SecureRandom.hex(4) }
     let(:service_build_url) { SecureRandom.hex(4) }
@@ -302,7 +302,7 @@ describe Coveralls::Configuration do
 
     it 'should set the expected parameters' do
       config = {}
-      Coveralls::Configuration.set_standard_service_params_for_generic_ci(config)
+      Coveralls::Configuration.define_standard_service_params_for_generic_ci(config)
       config[:service_name].should eq(service_name)
       config[:service_number].should eq(service_number)
       config[:service_build_url].should eq(service_build_url)
@@ -311,7 +311,7 @@ describe Coveralls::Configuration do
     end
   end
 
-  describe '.set_service_params_for_appveyor' do
+  describe '.define_service_params_for_appveyor' do
     let(:service_number) { SecureRandom.hex(4) }
     let(:service_branch) { SecureRandom.hex(4) }
     let(:commit_sha) { SecureRandom.hex(4) }
@@ -326,7 +326,7 @@ describe Coveralls::Configuration do
 
     it 'should set the expected parameters' do
       config = {}
-      Coveralls::Configuration.set_service_params_for_appveyor(config)
+      Coveralls::Configuration.define_service_params_for_appveyor(config)
       config[:service_name].should eq('appveyor')
       config[:service_number].should eq(service_number)
       config[:service_branch].should eq(service_branch)


### PR DESCRIPTION
- [x] Fix several rubocop violations

I'd like to show an interesting rubocop violation that I enabled as `false` in our `.rubocop.yml`. Let me know if I should `enabled: true` and make a new change. The `Cop` name is `Gemspec/RequiredRubyVersion`.

````
coveralls-ruby.gemspec:24:31: C: Gemspec/RequiredRubyVersion: required_ruby_version (1.9, declared in coveralls-ruby.gemspec) and TargetRubyVersion (2.3, which may be specified in .rubocop.yml) should be equal.
  gem.required_ruby_version = '>= 1.9.3'
                              ^^^^^^^^^^
```