### PR TITLE
Fix service name overriding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,13 +7,13 @@ AllCops:
     - 'vendor/bundle/**/*'
 
 Metrics/AbcSize:
-  Max: 38.2
+  Max: 39.29
 
 Metrics/CyclomaticComplexity:
-  Max: 18
+  Max: 19
 
 Metrics/PerceivedComplexity:
-  Max: 19
+  Max: 20
 
 Metrics/BlockLength:
   Exclude:

--- a/lib/coveralls/configuration.rb
+++ b/lib/coveralls/configuration.rb
@@ -51,9 +51,11 @@ module Coveralls
 
         # standardized env vars
         define_standard_service_params_for_generic_ci(config)
-        service_name = ENV['COVERALLS_SERVICE_NAME']
 
-        config[:service_name] = service_name
+        if ENV['COVERALLS_SERVICE_NAME']
+          config[:service_name] = ENV['COVERALLS_SERVICE_NAME']
+        end
+
         config
       end
 


### PR DESCRIPTION
Service name has to be overrides only if ENV contains the
COVERALLS_SERVICE_NAME variable.

Ref: 38f368ea338c6776ba268cecf3388607c206ab24

Fix #15