### PR TITLE
Use Active Support’s silence_stream implementation

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -68,13 +68,12 @@ def silence
   end
 end
 
-module Kernel
-  def silence_stream(stream)
-    old_stream = stream.dup
-    stream.reopen(RUBY_PLATFORM =~ /mswin/ ? 'NUL:' : '/dev/null')
-    stream.sync = true
-    yield
-  ensure
-    stream.reopen(old_stream)
-  end
+def silence_stream(stream)
+  old_stream = stream.dup
+  stream.reopen(IO::NULL)
+  stream.sync = true
+  yield
+ensure
+  stream.reopen(old_stream)
+  old_stream.close
 end


### PR DESCRIPTION
The old implementation of `silence_stream` has been removed from Rails.

This commit replaces the old `silence_stream` implementation with the
new one that we can actually find in Active Support.

Refs:
- rails/rails@481e49c64f790e46f4aff3ed539ed227d2eb46cb
- rails/rails#13392