### PR TITLE
Rescue from Load Errors

### DIFF
--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -44,6 +44,7 @@ module Coveralls
       begin
         require 'simplecov'
         @adapter = :simplecov if defined?(::SimpleCov)
+      rescue LoadError # rubocop:disable Lint/HandleExceptions
       rescue StandardError => e
         # TODO: Add error action
         puts e.message

--- a/lib/coveralls/api.rb
+++ b/lib/coveralls/api.rb
@@ -55,6 +55,7 @@ module Coveralls
 
           allow = WebMock::Config.instance.allow || []
           WebMock::Config.instance.allow = [*allow].push API_HOST
+        rescue LoadError # rubocop:disable Lint/HandleExceptions
         rescue StandardError => e
           # TODO: Add error action
           puts e.message
@@ -66,9 +67,10 @@ module Coveralls
           VCR.send(VCR.version.major < 2 ? :config : :configure) do |c|
             c.ignore_hosts API_HOST
           end
-        rescue StandardError
+        rescue LoadError # rubocop:disable Lint/HandleExceptions
+        rescue StandardError => e
           # TODO: Add error action
-          puts error.message
+          puts e.message
         end
       end
 

--- a/lib/coveralls/output.rb
+++ b/lib/coveralls/output.rb
@@ -65,11 +65,14 @@ module Coveralls
     # Returns the formatted string.
     def format(string, options = {})
       unless no_color?
-        require 'term/ansicolor'
-        options[:color]&.split(/\s/)&.reverse_each do |color|
-          next unless Term::ANSIColor.respond_to?(color.to_sym)
+        begin
+          require 'term/ansicolor'
+          options[:color]&.split(/\s/)&.reverse_each do |color|
+            next unless Term::ANSIColor.respond_to?(color.to_sym)
 
-          string = Term::ANSIColor.send(color.to_sym, string)
+            string = Term::ANSIColor.send(color.to_sym, string)
+          end
+        rescue LoadError # rubocop:disable Lint/HandleExceptions
         end
       end
       string


### PR DESCRIPTION
Commit 1c349b2 changed LoadError to StandardError to fix some RuboCop
offences.

As per Ruby docs, LoadError is not a subclass of StandardError but it is
a subclass of ScriptError.

When we try to require files inside Coveralls, we are going to rescue
From LoadError as well as StandardError.

Ref:
- https://ruby-doc.org/core-2.6.3/Exception.html