### PR TITLE
Do not rescue from LoadError with required gems

### DIFF
--- a/lib/coveralls.rb
+++ b/lib/coveralls.rb
@@ -44,7 +44,6 @@ module Coveralls
       begin
         require 'simplecov'
         @adapter = :simplecov if defined?(::SimpleCov)
-      rescue LoadError # rubocop:disable Lint/HandleExceptions
       rescue StandardError => e
         # TODO: Add error action
         puts e.message

--- a/lib/coveralls/output.rb
+++ b/lib/coveralls/output.rb
@@ -65,14 +65,11 @@ module Coveralls
     # Returns the formatted string.
     def format(string, options = {})
       unless no_color?
-        begin
-          require 'term/ansicolor'
-          options[:color]&.split(/\s/)&.reverse_each do |color|
-            next unless Term::ANSIColor.respond_to?(color.to_sym)
+        require 'term/ansicolor'
+        options[:color]&.split(/\s/)&.reverse_each do |color|
+          next unless Term::ANSIColor.respond_to?(color.to_sym)
 
-            string = Term::ANSIColor.send(color.to_sym, string)
-          end
-        rescue LoadError # rubocop:disable Lint/HandleExceptions
+          string = Term::ANSIColor.send(color.to_sym, string)
         end
       end
       string


### PR DESCRIPTION
`simplecov` and `term-ansicolor` are required gems, so coveralls must
raise an error if it is unable to require one of them.

/cc @pboling @AlexWayfer

Ref: #27